### PR TITLE
Refactor: Integrate the io.github.jisungbin.erratum.time package into…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,26 +1,7 @@
 group = "io.foreshore.cookware"
 version = "0.0.1-SNAPSHOT"
 
-val nexusUser:String by project
-val nexusPassword:String by project
-val nexus:String by project
-val nexusSnapshot:String by project
-val nexusRelease:String by project
-
-val repo:String = System.getenv("CI_NEXUS") ?: nexus
-val repoSnapshot:String = System.getenv("CI_NEXUS_SNAPSHOT") ?: nexusSnapshot
-val repoRelease:String = System.getenv("CI_NEXUS_RELEASE") ?: nexusRelease
-val repoUser:String = System.getenv("CI_NEXUS_USER") ?: nexusUser
-val repoPassword:String = System.getenv("CI_NEXUS_PASSWORD") ?: nexusPassword
-
 repositories {
-    maven {
-        url = uri(repo)
-        credentials {
-            username = repoUser
-            password = repoPassword
-        }
-    }
     mavenCentral()
 }
 
@@ -102,22 +83,5 @@ tasks.jacocoTestReport {
     reports {
         html.required.set(true)
         xml.required.set(true)
-    }
-}
-
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            from(components["java"])
-        }
-    }
-    repositories {
-        maven {
-            credentials {
-                username = repoUser
-                password = repoPassword
-            }
-            url = uri(if(project.version.toString().contains("SNAPSHOT", true)) repoSnapshot else repoRelease)
-        }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,12 +2,7 @@ rootProject.name = "cookware"
 
 pluginManagement {
     repositories {
-        maven {
-            url = uri(System.getenv("CI_NEXUS") ?: extra["nexus"] as String)
-            credentials {
-                username = System.getenv("CI_NEXUS_USER") ?: extra["nexusUser"] as String
-                password = System.getenv("CI_NEXUS_PASSWORD") ?: extra["nexusPassword"] as String
-            }
-        }
+        gradlePluginPortal()
+        mavenCentral()
     }
 }

--- a/src/main/kotlin/io/foreshore/cookware/time/TimeProvider.kt
+++ b/src/main/kotlin/io/foreshore/cookware/time/TimeProvider.kt
@@ -1,4 +1,4 @@
-package io.github.jisungbin.erratum.time
+package io.foreshore.cookware.time
 
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter

--- a/src/test/kotlin/io/foreshore/cookware/time/TimeProviderTest.kt
+++ b/src/test/kotlin/io/foreshore/cookware/time/TimeProviderTest.kt
@@ -1,5 +1,6 @@
-package io.github.jisungbin.erratum.time
+package io.foreshore.cookware.time
 
+import io.foreshore.cookware.time.TimeProvider
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime


### PR DESCRIPTION
… io.foreshore.cookware

- Move the TimeProvider.kt file to the io.foreshore.cookware.time package
- Move the TimeProviderTest.kt file to the io.foreshore.cookware.time package and update the relevant import statements
- Delete the existing io.github.jisungbin.erratum.time related directories
- Resolve test execution issues by removing Nexus-related dependencies from the Gradle build script